### PR TITLE
Include cstring for memcpy

### DIFF
--- a/download.cpp
+++ b/download.cpp
@@ -7,6 +7,7 @@
 
 #include <cstdlib>
 #include <curl/curl.h>
+#include <cstring>
 
 #include "download.h"
 


### PR DESCRIPTION
Memcpy isn't defined without this header.