### PR TITLE
Staticaly link glibc 

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -54,7 +54,7 @@ rapidJsonPath=${rootPath}/rapidjson
 
 cflags +=  -I ${sgExportPath} ${platformCompileFlags}
 cppflags +=  -I ${sgExportPath} -I ${rapidJsonPath}/include ${platformCompileFlags}
-basicLibs = ${sgExportPath}/sgExport.a -lz ${platformLinkFlags} -lcurl
+basicLibs = ${sgExportPath}/sgExport.a -static-libstdc++ -static-libgcc -lz ${platformLinkFlags} -lcurl
 basicLibsDependencies = ${sgExportPath}/sgExport.a
 
 


### PR DESCRIPTION
In case we build on C++11 GCC and want to run elsewhere.